### PR TITLE
fix `DefaultTranscoder` type so user can change it

### DIFF
--- a/transcoding.go
+++ b/transcoding.go
@@ -20,7 +20,7 @@ type (
 
 // DefaultTranscoder is the default transcoder across databases, it's the JSON by default.
 // Change it if you want a different serialization/deserialization inside your session databases (when `UseDatabase` is used).
-var DefaultTranscoder = defaultTranscoder{}
+var DefaultTranscoder Transcoder = defaultTranscoder{}
 
 type defaultTranscoder struct{}
 


### PR DESCRIPTION
You can't change default transcoder now becuase it has `defaultTranscoder` type, so you can't assign a `Transcoder` to it.

```golang
var t sessions.Transcoder = gobTranscoder{} // pass
sessions.DefaultTranscoder = t // error
```

you will get a error

.\main.go:56:31: cannot use t (variable of type sessions.Transcoder) as sessions.defaultTranscoder value in assignment: need type assertion